### PR TITLE
Agregar pesos a los jugadores en TS y TTT

### DIFF
--- a/src/TrueSkill.jl
+++ b/src/TrueSkill.jl
@@ -171,15 +171,14 @@ function Base.:-(N::Gaussian, M::Gaussian)
     return Gaussian(mu, sigma)
 end
 function Base.:*(N::Gaussian, M::Gaussian)
-    if _pi_(N) == Inf || _pi_(M) == Inf
-        return Gaussian(
-            N.mu/(N.sigma^2/M.sigma^2 + 1) + M.mu/(M.sigma^2/N.sigma^2 + 1),
-            sqrt(1/((1/N.sigma^2) + (1/M.sigma^2)))
-        )
+    if N.sigma == 0.0|| M.sigma == 0.0
+        mu = N.mu/(N.sigma^2/M.sigma^2 + 1) + M.mu/(M.sigma^2/N.sigma^2 + 1)
+        sigma = sqrt(1/((1/N.sigma^2) + (1/M.sigma^2)))
+    else
+        _pi = _pi_(N) + _pi_(M)
+        _tau = _tau_(N) + _tau_(M)
+        mu, sigma = mu_sigma(_tau, _pi)
     end
-    _pi = _pi_(N) + _pi_(M)
-    _tau = _tau_(N) + _tau_(M)
-    mu, sigma = mu_sigma(_tau, _pi)
     return Gaussian(mu, sigma)        
 end
 function Base.:*(N::Float64, M::Gaussian)
@@ -191,15 +190,14 @@ function Base.:*(M::Gaussian, N::Float64)
     return Gaussian(N*M.mu, abs(N)*M.sigma)
 end
 function Base.:/(N::Gaussian, M::Gaussian)
-    if _pi_(N) == Inf || _pi_(M) == Inf
-        return Gaussian(
-            N.mu/(1 - N.sigma^2/M.sigma^2) - M.mu/(M.sigma^2/N.sigma^2 - 1),
-            sqrt(1/((1/N.sigma^2) - (1/M.sigma^2)))
-        )
+    if N.sigma == 0.0|| M.sigma == 0.0
+        mu = N.mu/(1 - N.sigma^2/M.sigma^2) - M.mu/(M.sigma^2/N.sigma^2 - 1)
+        sigma =  sqrt(1/((1/N.sigma^2) - (1/M.sigma^2)))
+    else
+        _pi = _pi_(N) - _pi_(M)
+        _tau = _tau_(N) - _tau_(M)
+        mu, sigma = mu_sigma(_tau, _pi)
     end
-    _pi = _pi_(N) - _pi_(M)
-    _tau = _tau_(N) - _tau_(M)
-    mu, sigma = mu_sigma(_tau, _pi)
     return Gaussian(mu, sigma)        
 end
 function Base.isapprox(N::Gaussian, M::Gaussian, atol::Real=0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -558,5 +558,59 @@ using Test
         
         
     end
+    @testset "1vs1 with weights" begin
+        ta = [ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0)]
+        wa = [1.0]
+        tb = [ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0)]
+        wb = [2.0]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(30.625173, 7.765472), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(13.749653, 5.733840), 1e-4)
+
+        wa = [1.0]
+        wb = [0.7]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(27.630080, 7.206676), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(23.158943, 7.801628), 1e-4)
+
+        wa = [1.6]
+        wb = [0.7]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(26.142438, 7.573088), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(24.500183, 8.193278), 1e-4)
+    end
+    @testset "NvsN with weights" begin
+        ta = [ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0), ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0)]
+        wa = [0.4, 0.8]
+        tb = [ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0), ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0)]
+        wb = [0.9, 0.6]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(27.539023, 8.129639), 1e-4)
+        @test isapprox(post[1][2], ttt.Gaussian(30.078046, 7.485372), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(19.287197, 7.243465), 1e-4)
+        @test isapprox(post[2][2], ttt.Gaussian(21.191465, 7.867608), 1e-4)
+
+        wa = [1.3, 1.5]
+        wb = [0.7, 0.4]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(25.190190, 8.220511), 1e-4)
+        @test isapprox(post[1][2], ttt.Gaussian(25.219450, 8.182783), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(24.897589, 8.300779), 1e-4)
+        @test isapprox(post[2][2], ttt.Gaussian(24.941479, 8.322717), 1e-4)
+
+        wa = [1.6, 0.2]
+        wb = [0.7, 2.4]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(31.674697, 7.501180), 1e-4)
+        @test isapprox(post[1][2], ttt.Gaussian(25.834337, 8.320970), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(22.079819, 8.180607), 1e-4)
+        @test isapprox(post[2][2], ttt.Gaussian(14.987953, 6.308469), 1e-4)
+    end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -628,14 +628,19 @@ using Test
         @test isapprox(post[2][1], ttt.Gaussian(22.079819, 8.180607), 1e-4)
         @test isapprox(post[2][2], ttt.Gaussian(14.987953, 6.308469), 1e-4)
 
+    
+        tc = [ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0)]
+        g = ttt.Game([ta,tc])
+        post_2vs1 = ttt.posteriors(g)
+        
         wa = [1.0, 1.0]
         wb = [1.0, 0.0]
         g = ttt.Game([ta,tb], weights=[wa,wb])
         post = ttt.posteriors(g)
-        @test isapprox(post[1][1], ttt.Gaussian(25.550478, 8.091449), 1e-4)
-        @test isapprox(post[1][2], ttt.Gaussian(25.550478, 8.091449), 1e-4)
-        @test isapprox(post[2][1], ttt.Gaussian(24.449521, 8.091449), 1e-4)
-        @test isapprox(post[2][2], ttt.Gaussian(25.000000, 8.333333), 1e-4)
+        @test isapprox(post[1][1], post_2vs1[1][1], 1e-4)
+        @test isapprox(post[1][2], post_2vs1[1][2], 1e-4)
+        @test isapprox(post[2][1], post_2vs1[2][1], 1e-4)
+        @test isapprox(post[2][2], tb[2].prior, 1e-4)
     end
     @testset "1vs1 TTT with weights" begin
         composition = [[["a"],["b"]], [["b"],["a"]]]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -587,7 +587,7 @@ using Test
         tb = [ttt.Player(ttt.Gaussian(2.0,6.0),1.0,0.0)]
         g = ttt.Game([ta,tb], weights=[wa,wb])
         post = ttt.posteriors(g)
-        @test isapprox(post[1][1], ttt.Gaussian(5.557176746, 4.0527906913), 1e-4)
+        @test isapprox(post[1][1], ttt.Gaussian(5.557176746, 4.0527906913), 1e-3)
         @test isapprox(post[2][1], ttt.Gaussian(2.0, 6.0), 1e-4)
         # NOTA: trueskill original tiene probelmas en la aproximación: post[2][1].mu = 1.999644 
         
@@ -627,6 +627,15 @@ using Test
         @test isapprox(post[1][2], ttt.Gaussian(25.834337, 8.320970), 1e-4)
         @test isapprox(post[2][1], ttt.Gaussian(22.079819, 8.180607), 1e-4)
         @test isapprox(post[2][2], ttt.Gaussian(14.987953, 6.308469), 1e-4)
+
+        wa = [1.0, 1.0]
+        wb = [1.0, 0.0]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(25.550478, 8.091449), 1e-4)
+        @test isapprox(post[1][2], ttt.Gaussian(25.550478, 8.091449), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(24.449521, 8.091449), 1e-4)
+        @test isapprox(post[2][2], ttt.Gaussian(25.000000, 8.333333), 1e-4)
     end
     @testset "1vs1 TTT with weights" begin
         composition = [[["a"],["b"]], [["b"],["a"]]]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -415,15 +415,15 @@ using Test
         results = [[1.,0.],[0.,1.],[1.,0.]]
         
         h = ttt.History(composition=composition, results=results, times = [0, 10, 20], mu=0.0,sigma=6.0, beta=1.0, gamma=0.05)
-        @test Base.summarysize(h) < 3700
-        @test Base.summarysize(h.batches) - Base.summarysize(h.agents) < 2900
+        @test Base.summarysize(h) < 3850
+        @test Base.summarysize(h.batches) - Base.summarysize(h.agents) < 3100
         @test Base.summarysize(h.agents) < 700
-        @test Base.summarysize(h.batches[2]) - Base.summarysize(h.agents)  < 946
+        @test Base.summarysize(h.batches[2]) - Base.summarysize(h.agents)  < 1000
         
-        @test Base.summarysize(h) < Base.summarysize(composition)  * 6.5
+        @test Base.summarysize(h) < Base.summarysize(composition)  * 7
         
         @test Base.summarysize(h.batches[1].skills) == 618
-        @test Base.summarysize(h.batches[1].events) == 314
+        @test Base.summarysize(h.batches[1].events) == 362
     end
     @testset "Learning curves" begin
         composition = [ [["aj"],["bj"]],[["bj"],["cj"]], [["cj"],["aj"]] ]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -581,7 +581,23 @@ using Test
         post = ttt.posteriors(g)
         @test isapprox(post[1][1], ttt.Gaussian(26.142438, 7.573088), 1e-4)
         @test isapprox(post[2][1], ttt.Gaussian(24.500183, 8.193278), 1e-4)
-    end
+        
+        wa = [1.0]; wb = [0.0]
+        ta = [ttt.Player(ttt.Gaussian(2.0,6.0),1.0,0.0)]
+        tb = [ttt.Player(ttt.Gaussian(2.0,6.0),1.0,0.0)]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], ttt.Gaussian(5.557176746, 4.0527906913), 1e-4)
+        @test isapprox(post[2][1], ttt.Gaussian(2.0, 6.0), 1e-4)
+        # NOTA: trueskill original tiene probelmas en la aproximación: post[2][1].mu = 1.999644 
+        
+        wa = [1.0]; wb = [-1.0]
+        ta = [ttt.Player(ttt.Gaussian(2.0,6.0),1.0,0.0)]
+        tb = [ttt.Player(ttt.Gaussian(2.0,6.0),1.0,0.0)]
+        g = ttt.Game([ta,tb], weights=[wa,wb])
+        post = ttt.posteriors(g)
+        @test isapprox(post[1][1], post[2][1], 1e-4)
+        end
     @testset "NvsN with weights" begin
         ta = [ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0), ttt.Player(ttt.Gaussian(25.0,25.0/3),25.0/6,0.0)]
         wa = [0.4, 0.8]
@@ -611,6 +627,29 @@ using Test
         @test isapprox(post[1][2], ttt.Gaussian(25.834337, 8.320970), 1e-4)
         @test isapprox(post[2][1], ttt.Gaussian(22.079819, 8.180607), 1e-4)
         @test isapprox(post[2][2], ttt.Gaussian(14.987953, 6.308469), 1e-4)
+    end
+    @testset "1vs1 TTT with weights" begin
+        composition = [[["a"],["b"]], [["b"],["a"]]]
+        weights = [[[5.0],[4.0]],[[5.0],[4.0]]]
+        h = ttt.History(composition, mu=2.0, beta=1.0, sigma=6.0, gamma=0.0, weights=weights)
+        lc = ttt.learning_curves(h)
+        @test isapprox(lc["a"][1][2], ttt.Gaussian(5.53765944, 4.758722), 1e-4)
+        @test isapprox(lc["b"][1][2], ttt.Gaussian(-0.83012755, 5.2395689), 1e-4)
+        @test isapprox(lc["a"][2][2], ttt.Gaussian(1.7922776, 4.099566689), 1e-4)
+        @test isapprox(lc["b"][2][2], ttt.Gaussian(4.8455331752, 3.7476161), 1e-4)
+        
+        ttt.convergence(h)
+        lc = ttt.learning_curves(h)
+        @test isapprox(lc["a"][1][2], ttt.Gaussian(lc["a"][1][2].mu, lc["a"][1][2].sigma), 1e-4)
+        @test isapprox(lc["b"][1][2], ttt.Gaussian(lc["a"][1][2].mu, lc["a"][1][2].sigma), 1e-4)
+        @test isapprox(lc["a"][2][2], ttt.Gaussian(lc["a"][1][2].mu, lc["a"][1][2].sigma), 1e-4)
+        @test isapprox(lc["b"][2][2], ttt.Gaussian(lc["a"][1][2].mu, lc["a"][1][2].sigma), 1e-4)
+        
+        composition = [[["a"],["b"]], [["b"],["a"]]]
+        weights = [[[1.0],[4.0]],[[5.0],[4.0]]]
+        h = ttt.History(composition, mu=2.0, beta=1.0, sigma=6.0, gamma=0.0, weights=weights)
+        lc = ttt.learning_curves(h)
+        
     end
 end
 


### PR DESCRIPTION
Se agrega la posibilidad de agregarle un multiplicador al rendimiento de cada jugador. Esto permite modelar efectos externos lineales. Pero debe ser evitado para modelar participación parcial de un mismo jugador.  

## Pendiente:
- [x] Pesos en TS
- [x] Tests: Game 1vs1. (Error con peso 0)
- [x] Revisar en TTT
- [x] Tests en TTT
- [x] Test de memoria